### PR TITLE
Fix a panic on haproxy reload

### DIFF
--- a/peers/conn.go
+++ b/peers/conn.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"syscall"
 	"time"
 )
 
@@ -257,7 +258,7 @@ func (c *Conn) serve() {
 
 	for {
 		err := c.Read()
-		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
+		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF || errors.Is(err, syscall.ECONNRESET)) {
 			return
 		}
 

--- a/peers/conn.go
+++ b/peers/conn.go
@@ -258,7 +258,7 @@ func (c *Conn) serve() {
 
 	for {
 		err := c.Read()
-		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF || errors.Is(err, syscall.ECONNRESET)) {
+		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET) {
 			return
 		}
 


### PR DESCRIPTION
During a reload haproxy sometimes resets the connection and we don't want to panic because of that.